### PR TITLE
Fix integration with chai-as-promised (closes #6)

### DIFF
--- a/src/chai-smoothie.ts
+++ b/src/chai-smoothie.ts
@@ -12,6 +12,14 @@ declare global {
             selected: Assertion;
             text(text: string): Assertion;
         }
+
+        interface PromisedAssertion {
+            displayed: PromisedAssertion;
+            present: PromisedAssertion;
+            enabled: PromisedAssertion;
+            selected: PromisedAssertion;
+            text(text: string): PromisedAssertion;
+        }
     }
 }
 


### PR DESCRIPTION
Adds type definitions for assertions chained after `eventually` to fix TS compiler errors (see #6) when using chai-smoothie together with chai-as-promised.
